### PR TITLE
Handle leave events

### DIFF
--- a/events.go
+++ b/events.go
@@ -7,13 +7,13 @@ import (
 
 // Event represents a single Matrix event.
 type Event struct {
-	StateKey  string                 `json:"state_key"`        // The state key for the event. Only present on State Events.
-	Sender    string                 `json:"sender"`           // The user ID of the sender of the event
-	Type      string                 `json:"type"`             // The event type
-	Timestamp int                    `json:"origin_server_ts"` // The unix timestamp when this message was sent by the origin server
-	ID        string                 `json:"event_id"`         // The unique ID of this event
-	RoomID    string                 `json:"room_id"`          // The room the event was sent to. May be nil (e.g. for presence)
-	Content   map[string]interface{} `json:"content"`          // The JSON content of the event.
+	StateKey  *string                `json:"state_key,omitempty"` // The state key for the event. Only present on State Events.
+	Sender    string                 `json:"sender"`              // The user ID of the sender of the event
+	Type      string                 `json:"type"`                // The event type
+	Timestamp int                    `json:"origin_server_ts"`    // The unix timestamp when this message was sent by the origin server
+	ID        string                 `json:"event_id"`            // The unique ID of this event
+	RoomID    string                 `json:"room_id"`             // The room the event was sent to. May be nil (e.g. for presence)
+	Content   map[string]interface{} `json:"content"`             // The JSON content of the event.
 }
 
 // Body returns the value of the "body" key in the event content if it is

--- a/responses.go
+++ b/responses.go
@@ -125,6 +125,16 @@ type RespSync struct {
 		Events []Event `json:"events"`
 	} `json:"presence"`
 	Rooms struct {
+		Leave map[string]struct {
+			State struct {
+				Events []Event `json:"events"`
+			} `json:"state"`
+			Timeline struct {
+				Events    []Event `json:"events"`
+				Limited   bool    `json:"limited"`
+				PrevBatch string  `json:"prev_batch"`
+			} `json:"timeline"`
+		} `json:"leave"`
 		Join map[string]struct {
 			State struct {
 				Events []Event `json:"events"`

--- a/room.go
+++ b/room.go
@@ -13,7 +13,7 @@ func (room Room) UpdateState(event *Event) {
 	if !exists {
 		room.State[event.Type] = make(map[string]*Event)
 	}
-	room.State[event.Type][event.StateKey] = event
+	room.State[event.Type][*event.StateKey] = event
 }
 
 // GetStateEvent returns the state event for the given type/state_key combo, or nil.

--- a/sync.go
+++ b/sync.go
@@ -112,7 +112,7 @@ func (s *DefaultSyncer) shouldProcessResponse(resp *RespSync, since string) bool
 	for roomID, roomData := range resp.Rooms.Join {
 		for i := len(roomData.Timeline.Events) - 1; i >= 0; i-- {
 			e := roomData.Timeline.Events[i]
-			if e.Type == "m.room.member" && *e.StateKey == s.UserID {
+			if e.Type == "m.room.member" && e.StateKey != nil && *e.StateKey == s.UserID {
 				m := e.Content["membership"]
 				mship, ok := m.(string)
 				if !ok {

--- a/sync.go
+++ b/sync.go
@@ -73,6 +73,14 @@ func (s *DefaultSyncer) ProcessResponse(res *RespSync, since string) (err error)
 			s.notifyListeners(&event)
 		}
 	}
+	for roomID, roomData := range res.Rooms.Leave {
+		room := s.getOrCreateRoom(roomID)
+		for _, event := range roomData.Timeline.Events {
+			event.RoomID = roomID
+			room.UpdateState(&event)
+			s.notifyListeners(&event)
+		}
+	}
 	return
 }
 

--- a/sync.go
+++ b/sync.go
@@ -76,9 +76,11 @@ func (s *DefaultSyncer) ProcessResponse(res *RespSync, since string) (err error)
 	for roomID, roomData := range res.Rooms.Leave {
 		room := s.getOrCreateRoom(roomID)
 		for _, event := range roomData.Timeline.Events {
-			event.RoomID = roomID
-			room.UpdateState(&event)
-			s.notifyListeners(&event)
+			if event.StateKey != nil {
+				event.RoomID = roomID
+				room.UpdateState(&event)
+				s.notifyListeners(&event)
+			}
 		}
 	}
 	return
@@ -110,7 +112,7 @@ func (s *DefaultSyncer) shouldProcessResponse(resp *RespSync, since string) bool
 	for roomID, roomData := range resp.Rooms.Join {
 		for i := len(roomData.Timeline.Events) - 1; i >= 0; i-- {
 			e := roomData.Timeline.Events[i]
-			if e.Type == "m.room.member" && e.StateKey == s.UserID {
+			if e.Type == "m.room.member" && *e.StateKey == s.UserID {
 				m := e.Content["membership"]
 				mship, ok := m.(string)
 				if !ok {


### PR DESCRIPTION
Leave events are currently unhandled by the SDK. 

It is useful for bots to have access to leave events so that they can clean up state etc. after having been kicked from a room.

@Kegsay can you please have a look at the following and let me know if it makes sense (specifically sync.go L78, using the timeline events in this way)? Thanks.