### PR TITLE
Prevent err from being clobbered when JSON unmarshals to nil result.

### DIFF
--- a/client.go
+++ b/client.go
@@ -281,7 +281,14 @@ func (cli *Client) register(u string, req *ReqRegister) (resp *RespRegister, uia
 		}
 		if httpErr.Code == 401 {
 			// body should be RespUserInteractive, if it isn't, fail with the error
-			err = json.Unmarshal(bodyBytes, &uiaResp)
+			err2 := json.Unmarshal(bodyBytes, &uiaResp)
+			if err2 != nil {
+				err = err2
+				return
+			}
+			if len(uiaResp.Flows) > 0 {
+				err = nil // We successfully unmarshalled into uiaresp so any HTTP errors can be discarded
+			}
 			return
 		}
 		return


### PR DESCRIPTION
This patch prevents a panic when a register request is unauthorised.

Example stacktrace produced when attempting to register a user with an invalid access token:

```
Request panicked!
goroutine 15490878 [running]:
runtime/debug.Stack(0xc421596550, 0xc4216455f0, 0xc4215965f0)
\t/usr/local/go/src/runtime/debug/stack.go:24 +0x79
github.com/matrix-org/util.Protect.func1.1(0xc4208f0800, 0xbd33a0, 0xc42198e380)
\t/home/scalar-staging/scalar/vendor/src/github.com/matrix-org/util/json.go:87 +0x14c
panic(0x8eb4e0, 0xbf8bf0)
\t/usr/local/go/src/runtime/panic.go:489 +0x2cf
github.com/matrix-org/scalar/bots/integrator.(*PersonalBotAPI).RegisterBot(0xc420075ad0, 0xc420325f80, 0x2e, 0xc420325f80, 0x2e)
\t/home/scalar-staging/scalar/src/github.com/matrix-org/scalar/bots/integrator/personalbot.go:66 +0x85e
github.com/matrix-org/scalar/bots/integrations/rssbot.(*RSSBot).configureService(0xc420075ad0, 0xc4208f0900, 0xc4207c6780, 0x12, 0x1, 0x0, 0x0, 0x0)
\t/home/scalar-staging/scalar/src/github.com/matrix-org/scalar/bots/integrations/rssbot/rssbot.go:119 +0x324
github.com/matrix-org/scalar/bots/integrations/rssbot.(*RSSBot).OnIncomingRequest(0xc420075ad0, 0xc4208f0900, 0xc4207c6780, 0x12, 0x0, 0xc4210ae380, 0xc4208f0900, 0xc4217382f0)
\t/home/scalar-staging/scalar/src/github.com/matrix-org/scalar/bots/integrations/rssbot/rssbot.go:71 +0x128
github.com/matrix-org/scalar/bots/integrator.APIWrapper.OnIncomingRequest(0xbd4220, 0xc420075ad0, 0xc4208f0900, 0x97dcd8, 0x9, 0xc4217382f0, 0xc)
\t/home/scalar-staging/scalar/src/github.com/matrix-org/scalar/bots/integrator/integrator.go:45 +0x21c
github.com/matrix-org/scalar/bots/integrator.(*APIWrapper).OnIncomingRequest(0xc420481480, 0xc4208f0900, 0xc074e0, 0xc420d7f655, 0xc4217f1bb0, 0x42b25e)
\t<autogenerated>:5 +0x60
github.com/matrix-org/util.MakeJSONAPI.func1(0xbd33a0, 0xc42198e380, 0xc4208f0900)
\t/home/scalar-staging/scalar/vendor/src/github.com/matrix-org/util/json.go:128 +0x7b
github.com/matrix-org/util.Protect.func1(0xbd33a0, 0xc42198e380, 0xc4208f0800)
\t/home/scalar-staging/scalar/vendor/src/github.com/matrix-org/util/json.go:92 +0x8b
github.com/matrix-org/util.WithCORSOptions.func1(0xbd33a0, 0xc42198e380, 0xc4208f0800)
\t/home/scalar-staging/scalar/vendor/src/github.com/matrix-org/util/json.go:171 +0x59
main.removeAPIPrefix.func1(0xbd33a0, 0xc42198e380, 0xc4208f0800)
\t/home/scalar-staging/scalar/src/github.com/matrix-org/scalar/cmd/scalar/scalar.go:132 +0x13b
net/http.HandlerFunc.ServeHTTP(0xc4204814d0, 0xbd33a0, 0xc42198e380, 0xc4208f0800)
\t/usr/local/go/src/net/http/server.go:1942 +0x44
net/http.(*ServeMux).ServeHTTP(0xc074e0, 0xbd33a0, 0xc42198e380, 0xc4208f0800)
\t/usr/local/go/src/net/http/server.go:2238 +0x130
net/http.serverHandler.ServeHTTP(0xc42043a2c0, 0xbd33a0, 0xc42198e380, 0xc4208f0800)
\t/usr/local/go/src/net/http/server.go:2568 +0x92
net/http.(*conn).serve(0xc420b98460, 0xbd3da0, 0xc4210ae240)
\t/usr/local/go/src/net/http/server.go:1825 +0x612
created by net/http.(*Server).Serve
\t/usr/local/go/src/net/http/server.go:2668 +0x2ce
" context=missing panic="runtime error: invalid memory address or nil pointer dereference"
```