### PR TITLE
Added default filter values & filter validation

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -23,11 +23,11 @@ type Filter struct {
 	EventFields []string   `json:"event_fields,omitempty"`
 	EventFormat string     `json:"event_format,omitempty"`
 	Presence    FilterPart `json:"presence,omitempty"`
-	Room        FilterRoom `json:"room,omitempty"`
+	Room        RoomFilter `json:"room,omitempty"`
 }
 
-// FilterRoom is used to define filtering rules for room events
-type FilterRoom struct {
+// RoomFilter is used to define filtering rules for room events
+type RoomFilter struct {
 	AccountData  FilterPart `json:"account_data,omitempty"`
 	Ephemeral    FilterPart `json:"ephemeral,omitempty"`
 	IncludeLeave bool       `json:"include_leave,omitempty"`
@@ -52,7 +52,7 @@ type FilterPart struct {
 // Validate checks if the filter contains valid property values
 func (filter *Filter) Validate() error {
 	if filter.EventFormat != "client" && filter.EventFormat != "federation" {
-		return errors.New("Bad event_format value. Must be any of [\"client\", \"federation\"]")
+		return errors.New("Bad event_format value. Must be one of [\"client\", \"federation\"]")
 	}
 	return nil
 }
@@ -64,7 +64,7 @@ func DefaultFilter() Filter {
 		EventFields: nil,
 		EventFormat: "client",
 		Presence:    DefaultFilterPart(),
-		Room: FilterRoom{
+		Room: RoomFilter{
 			AccountData:  DefaultFilterPart(),
 			Ephemeral:    DefaultFilterPart(),
 			IncludeLeave: false,

--- a/filter.go
+++ b/filter.go
@@ -14,6 +14,8 @@
 
 package gomatrix
 
+import "errors"
+
 //Filter is used by clients to specify how the server should filter responses to e.g. sync requests
 //Specified by: https://matrix.org/docs/spec/client_server/r0.2.0.html#filtering
 type Filter struct {
@@ -21,23 +23,68 @@ type Filter struct {
 	EventFields []string   `json:"event_fields,omitempty"`
 	EventFormat string     `json:"event_format,omitempty"`
 	Presence    FilterPart `json:"presence,omitempty"`
-	Room        struct {
-		AccountData  FilterPart `json:"account_data,omitempty"`
-		Ephemeral    FilterPart `json:"ephemeral,omitempty"`
-		IncludeLeave bool       `json:"include_leave,omitempty"`
-		NotRooms     []string   `json:"not_rooms,omitempty"`
-		Rooms        []string   `json:"rooms,omitempty"`
-		State        FilterPart `json:"state,omitempty"`
-		Timeline     FilterPart `json:"timeline,omitempty"`
-	} `json:"room,omitempty"`
+	Room        FilterRoom `json:"room,omitempty"`
 }
 
+// FilterRoom is used to define filtering rules for room events
+type FilterRoom struct {
+	AccountData  FilterPart `json:"account_data,omitempty"`
+	Ephemeral    FilterPart `json:"ephemeral,omitempty"`
+	IncludeLeave bool       `json:"include_leave,omitempty"`
+	NotRooms     []string   `json:"not_rooms,omitempty"`
+	Rooms        []string   `json:"rooms,omitempty"`
+	State        FilterPart `json:"state,omitempty"`
+	Timeline     FilterPart `json:"timeline,omitempty"`
+}
+
+// FilterPart is used to define filtering rules for specific categories of events
 type FilterPart struct {
-	NotRooms   []string `json:"not_rooms,omitempty"`
-	Rooms      []string `json:"rooms,omitempty"`
-	Limit      *int     `json:"limit,omitempty"`
-	NotSenders []string `json:"not_senders,omitempty"`
-	NotTypes   []string `json:"not_types,omitempty"`
-	Senders    []string `json:"senders,omitempty"`
-	Types      []string `json:"types,omitempty"`
+	NotRooms    []string `json:"not_rooms,omitempty"`
+	Rooms       []string `json:"rooms,omitempty"`
+	Limit       int      `json:"limit,omitempty"`
+	NotSenders  []string `json:"not_senders,omitempty"`
+	NotTypes    []string `json:"not_types,omitempty"`
+	Senders     []string `json:"senders,omitempty"`
+	Types       []string `json:"types,omitempty"`
+	ContainsURL *bool    `json:"contains_url,omitempty"`
+}
+
+// Validate checks if the filter contains valid property values
+func (filter *Filter) Validate() error {
+	if filter.EventFormat != "client" && filter.EventFormat != "federation" {
+		return errors.New("Bad event_format value. Must be any of [\"client\", \"federation\"]")
+	}
+	return nil
+}
+
+// DefaultFilter returns the default filter used by the Matrix server if no filter is provided in the request
+func DefaultFilter() Filter {
+	return Filter{
+		AccountData: DefaultFilterPart(),
+		EventFields: nil,
+		EventFormat: "client",
+		Presence:    DefaultFilterPart(),
+		Room: FilterRoom{
+			AccountData:  DefaultFilterPart(),
+			Ephemeral:    DefaultFilterPart(),
+			IncludeLeave: false,
+			NotRooms:     nil,
+			Rooms:        nil,
+			State:        DefaultFilterPart(),
+			Timeline:     DefaultFilterPart(),
+		},
+	}
+}
+
+// DefaultFilterPart returns the default filter part used by the Matrix server if no filter is provided in the request
+func DefaultFilterPart() FilterPart {
+	return FilterPart{
+		NotRooms:   nil,
+		Rooms:      nil,
+		Limit:      20,
+		NotSenders: nil,
+		NotTypes:   nil,
+		Senders:    nil,
+		Types:      nil,
+	}
 }


### PR DESCRIPTION
Added functions to build a "default" filter, similar to those used by Synapse if no filter is provided in the request.
Since implementations may differ, this may be better fitted inside Dendrite code (imho it's still useful to be able to build a working Filter with a single function call).

Also added `Validate()` to check if a Filter contains valid values (currently only checks `Filter.EventFormat`)