### PR TITLE
Bump minimum go version to 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
- - 1.8
+ - 1.10
+ - 1.11
 install:
  - go get github.com/golang/lint/golint
  - go get github.com/fzipp/gocyclo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 go:
  - 1.10.x
- - 1.11.x
 install:
  - go get github.com/golang/lint/golint
  - go get github.com/fzipp/gocyclo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
- - 1.10
- - 1.11
+ - 1.10.x
+ - 1.11.x
 install:
  - go get github.com/golang/lint/golint
  - go get github.com/fzipp/gocyclo

--- a/responses.go
+++ b/responses.go
@@ -168,6 +168,7 @@ type RespSync struct {
 	} `json:"rooms"`
 }
 
+// RespTurnServer is the JSON response from a Turn Server
 type RespTurnServer struct {
 	Username string   `json:"username"`
 	Password string   `json:"password"`

--- a/userids.go
+++ b/userids.go
@@ -125,6 +125,6 @@ func ExtractUserLocalpart(userID string) (string, error) {
 	}
 	return strings.TrimPrefix(
 		strings.SplitN(userID, ":", 2)[0], // @foo:bar:8448 => [ "@foo", "bar:8448" ]
-		"@", // remove "@" prefix
+		"@",                               // remove "@" prefix
 	), nil
 }

--- a/userids.go
+++ b/userids.go
@@ -125,6 +125,6 @@ func ExtractUserLocalpart(userID string) (string, error) {
 	}
 	return strings.TrimPrefix(
 		strings.SplitN(userID, ":", 2)[0], // @foo:bar:8448 => [ "@foo", "bar:8448" ]
-		"@",                               // remove "@" prefix
+		"@", // remove "@" prefix
 	), nil
 }


### PR DESCRIPTION
Bumps the minimum golang version to 1.10 due to latest Ubuntu LTS containing 1.10.