### PR TITLE
Added tags.go to support room tagging feature in dendrite

### DIFF
--- a/client.go
+++ b/client.go
@@ -69,7 +69,7 @@ func (cli *Client) BuildBaseURL(urlPath ...string) string {
 	parts := []string{hsURL.Path}
 	parts = append(parts, urlPath...)
 	hsURL.Path = path.Join(parts...)
-	// Manually add the trailing slash back to the end of the path if it's explicitely needed
+	// Manually add the trailing slash back to the end of the path if it's explicitly needed
 	if strings.HasSuffix(urlPath[len(urlPath)-1], "/") {
 		hsURL.Path = hsURL.Path + "/"
 	}

--- a/tags.go
+++ b/tags.go
@@ -1,7 +1,7 @@
 package gomatrix
 
-// Tags is based on the Room Tagging feature as described in https://matrix.org/docs/spec/client_server/r0.2.0.html#room-tagging
 // Tag contains the data for a Tag which can be referenced by the Tag name
+// Tags is based on the Room Tagging feature as described in https://matrix.org/docs/spec/client_server/r0.2.0.html#room-tagging
 type Tag struct {
 	Tags map[string]TagProperties `json:"tags"`
 }

--- a/tags.go
+++ b/tags.go
@@ -1,7 +1,6 @@
 package gomatrix
 
 // Tag contains the data for a Tag which can be referenced by the Tag name
-// Tags is based on the Room Tagging feature as described in https://matrix.org/docs/spec/client_server/r0.2.0.html#room-tagging
 type Tag struct {
 	Tags map[string]TagProperties `json:"tags"`
 }

--- a/tags.go
+++ b/tags.go
@@ -14,7 +14,7 @@
 
 package gomatrix
 
-// Tag contains the data for an m.tag message type
+// TagContent contains the data for an m.tag message type
 // https://matrix.org/docs/spec/client_server/r0.4.0.html#m-tag
 type TagContent struct {
 	Tags map[string]TagProperties `json:"tags"`

--- a/tags.go
+++ b/tags.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Sumukha PK
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gomatrix
 
 // Tag contains the data for a Tag which can be referenced by the Tag name

--- a/tags.go
+++ b/tags.go
@@ -1,0 +1,12 @@
+package gomatrix
+
+// Tags is based on the Room Tagging feature as described in https://matrix.org/docs/spec/client_server/r0.2.0.html#room-tagging
+// Tag contains the data for a Tag which can be referenced by the Tag name
+type Tag struct {
+	Tags map[string]TagProperties `json:"tags"`
+}
+
+// TagProperties contains the properties of an MTag
+type TagProperties struct {
+	Order float32 `json:"order,omitempty"` // Empty values must be neglected
+}

--- a/tags.go
+++ b/tags.go
@@ -16,7 +16,7 @@ package gomatrix
 
 // Tag contains the data for an m.tag message type
 // https://matrix.org/docs/spec/client_server/r0.4.0.html#m-tag
-type Tag struct {
+type TagContent struct {
 	Tags map[string]TagProperties `json:"tags"`
 }
 


### PR DESCRIPTION
Generic types are supposed to go in `gomatrix` so to support [Room Tagging PR](https://github.com/matrix-org/dendrite/pull/694) adding `tags.go` to `gomatrix`