### PR TITLE
extended ImageMessage for Thumbnail and added additional ImageTypes

### DIFF
--- a/events.go
+++ b/events.go
@@ -73,12 +73,14 @@ type VideoMessage struct {
 	Info    VideoInfo `json:"info"`
 }
 
-// ImageMessage is an m.image event
+// ImageMessage is an m.image event - http://matrix.org/docs/spec/client_server/r0.2.0.html#m-image
 type ImageMessage struct {
-	MsgType string    `json:"msgtype"`
-	Body    string    `json:"body"`
-	URL     string    `json:"url"`
-	Info    ImageInfo `json:"info"`
+	MsgType       string    `json:"msgtype"`
+	Body          string    `json:"body"`
+	URL           string    `json:"url"`
+	Info          ImageInfo `json:"info,omitempty"`
+	ThumbnailURL  string    `json:"thumbnail_url,omitempty"`
+	ThumbnailInfo ImageInfo `json:"thumbnail_info,omitempty"`
 }
 
 // An HTMLMessage is the contents of a Matrix HTML formated message event.

--- a/events.go
+++ b/events.go
@@ -48,10 +48,10 @@ type TextMessage struct {
 
 // ImageInfo contains info about an image - http://matrix.org/docs/spec/client_server/r0.2.0.html#m-image
 type ImageInfo struct {
-	Height   uint   `json:"h,omitempty"`
-	Width    uint   `json:"w,omitempty"`
+	Height   uint   `json:"h,omitempty"` //image height in pixels
+	Width    uint   `json:"w,omitempty"` //image width in pixels
 	Mimetype string `json:"mimetype,omitempty"`
-	Size     uint   `json:"size,omitempty"`
+	Size     uint   `json:"size,omitempty"` //filesize in bytes
 }
 
 // VideoInfo contains info about a video - http://matrix.org/docs/spec/client_server/r0.2.0.html#m-video
@@ -62,7 +62,7 @@ type VideoInfo struct {
 	Height        uint      `json:"h,omitempty"`
 	Width         uint      `json:"w,omitempty"`
 	Duration      uint      `json:"duration,omitempty"`
-	Size          uint      `json:"size,omitempty"`
+	Size          uint      `json:"size,omitempty"` //filesize in bytes
 }
 
 // VideoMessage is an m.video  - http://matrix.org/docs/spec/client_server/r0.2.0.html#m-video
@@ -89,6 +89,47 @@ type HTMLMessage struct {
 	MsgType       string `json:"msgtype"`
 	Format        string `json:"format"`
 	FormattedBody string `json:"formatted_body"`
+}
+
+// FileInfo contains info about an file - http://matrix.org/docs/spec/client_server/r0.2.0.html#m-file
+type FileInfo struct {
+	Mimetype string `json:"mimetype,omitempty"`
+	Size     uint   `json:"size,omitempty"` //filesize in bytes
+}
+
+// FileMessage is an m.file event - http://matrix.org/docs/spec/client_server/r0.2.0.html#m-file
+type FileMessage struct {
+	MsgType       string    `json:"msgtype"`
+	Body          string    `json:"body"`
+	URL           string    `json:"url"`
+	Filename      string    `json:"filename"`
+	Info          FileInfo  `json:"info,omitempty"`
+	ThumbnailURL  string    `json:"thumbnail_url,omitempty"`
+	ThumbnailInfo ImageInfo `json:"thumbnail_info,omitempty"`
+}
+
+// LocationMessage is an m.location event - http://matrix.org/docs/spec/client_server/r0.2.0.html#m-location
+type LocationMessage struct {
+	MsgType       string    `json:"msgtype"`
+	Body          string    `json:"body"`
+	GeoURI        string    `json:"geo_uri"`
+	ThumbnailURL  string    `json:"thumbnail_url,omitempty"`
+	ThumbnailInfo ImageInfo `json:"thumbnail_info,omitempty"`
+}
+
+// AudioInfo contains info about an file - http://matrix.org/docs/spec/client_server/r0.2.0.html#m-audio
+type AudioInfo struct {
+	Mimetype string `json:"mimetype,omitempty"`
+	Size     uint   `json:"size,omitempty"`     //filesize in bytes
+	Duration uint   `json:"duration,omitempty"` //audio duration in ms
+}
+
+// AudioMessage is an m.audio event - http://matrix.org/docs/spec/client_server/r0.2.0.html#m-audio
+type AudioMessage struct {
+	MsgType string    `json:"msgtype"`
+	Body    string    `json:"body"`
+	URL     string    `json:"url"`
+	Info    AudioInfo `json:"info,omitempty"`
 }
 
 var htmlRegex = regexp.MustCompile("<[^<]+?>")


### PR DESCRIPTION
This should now be the correct way to do it.

I've added ThumbnailURL and ThumbnailInfo to the ImageMessage struct so Thumbnails can be added, which is important for e.g. mobile clients.

While at it, I've also added strucs for other message types, in case someone needs them, like I needed the thumbnails.

Finally, I've added some comments on what information in what unit a field should contain, if it's not obvious. (e.g. Mastodon has a field "size" in its imageInfo which contains a string like "WxH" )
