### PR TITLE
ImageInfo can have a Thumbnail (and it's needed for Riot on Android)

### DIFF
--- a/events.go
+++ b/events.go
@@ -46,23 +46,33 @@ type TextMessage struct {
 	Body    string `json:"body"`
 }
 
-// ImageInfo contains info about an image - http://matrix.org/docs/spec/client_server/r0.2.0.html#m-image
-type ImageInfo struct {
+// ThumbnailInfo contains info about an thumbnail image - http://matrix.org/docs/spec/client_server/r0.2.0.html#m-image
+type ThumbnailInfo struct {
 	Height   uint   `json:"h,omitempty"`
 	Width    uint   `json:"w,omitempty"`
 	Mimetype string `json:"mimetype,omitempty"`
 	Size     uint   `json:"size,omitempty"`
 }
 
+// ImageInfo contains info about an image - http://matrix.org/docs/spec/client_server/r0.2.0.html#m-image
+type ImageInfo struct {
+	Height        uint          `json:"h,omitempty"`
+	Width         uint          `json:"w,omitempty"`
+	Mimetype      string        `json:"mimetype,omitempty"`
+	Size          uint          `json:"size,omitempty"`
+	ThumbnailInfo ThumbnailInfo `json:"thumbnail_info,omitempty"`
+	ThumbnailURL  string        `json:"thumbnail_url,omitempty"`
+}
+
 // VideoInfo contains info about a video - http://matrix.org/docs/spec/client_server/r0.2.0.html#m-video
 type VideoInfo struct {
-	Mimetype      string    `json:"mimetype,omitempty"`
-	ThumbnailInfo ImageInfo `json:"thumbnail_info"`
-	ThumbnailURL  string    `json:"thumbnail_url,omitempty"`
-	Height        uint      `json:"h,omitempty"`
-	Width         uint      `json:"w,omitempty"`
-	Duration      uint      `json:"duration,omitempty"`
-	Size          uint      `json:"size,omitempty"`
+	Mimetype      string        `json:"mimetype,omitempty"`
+	ThumbnailInfo ThumbnailInfo `json:"thumbnail_info"`
+	ThumbnailURL  string        `json:"thumbnail_url,omitempty"`
+	Height        uint          `json:"h,omitempty"`
+	Width         uint          `json:"w,omitempty"`
+	Duration      uint          `json:"duration,omitempty"`
+	Size          uint          `json:"size,omitempty"`
 }
 
 // VideoMessage is an m.video  - http://matrix.org/docs/spec/client_server/r0.2.0.html#m-video


### PR DESCRIPTION
I screwed up and closed https://github.com/matrix-org/gomatrix/pull/63 which was actually valid, and couldn't reopen it anymore, so I'm porting the commit here.

@btittelbach thank you very much for your contribution and very sorry for the overall mess.

FTR the original PR lgtm so I'm merging this.