### PR TITLE
support for ephemeral events and more message types

### DIFF
--- a/events.go
+++ b/events.go
@@ -99,6 +99,47 @@ type HTMLMessage struct {
 	FormattedBody string `json:"formatted_body"`
 }
 
+// FileInfo contains info about an file - http://matrix.org/docs/spec/client_server/r0.2.0.html#m-file
+type FileInfo struct {
+	Mimetype string `json:"mimetype,omitempty"`
+	Size     uint   `json:"size,omitempty"` //filesize in bytes
+}
+
+// FileMessage is an m.file event - http://matrix.org/docs/spec/client_server/r0.2.0.html#m-file
+type FileMessage struct {
+	MsgType       string    `json:"msgtype"`
+	Body          string    `json:"body"`
+	URL           string    `json:"url"`
+	Filename      string    `json:"filename"`
+	Info          FileInfo  `json:"info,omitempty"`
+	ThumbnailURL  string    `json:"thumbnail_url,omitempty"`
+	ThumbnailInfo ImageInfo `json:"thumbnail_info,omitempty"`
+}
+
+// LocationMessage is an m.location event - http://matrix.org/docs/spec/client_server/r0.2.0.html#m-location
+type LocationMessage struct {
+	MsgType       string    `json:"msgtype"`
+	Body          string    `json:"body"`
+	GeoURI        string    `json:"geo_uri"`
+	ThumbnailURL  string    `json:"thumbnail_url,omitempty"`
+	ThumbnailInfo ImageInfo `json:"thumbnail_info,omitempty"`
+}
+
+// AudioInfo contains info about an file - http://matrix.org/docs/spec/client_server/r0.2.0.html#m-audio
+type AudioInfo struct {
+	Mimetype string `json:"mimetype,omitempty"`
+	Size     uint   `json:"size,omitempty"`     //filesize in bytes
+	Duration uint   `json:"duration,omitempty"` //audio duration in ms
+}
+
+// AudioMessage is an m.audio event - http://matrix.org/docs/spec/client_server/r0.2.0.html#m-audio
+type AudioMessage struct {
+	MsgType string    `json:"msgtype"`
+	Body    string    `json:"body"`
+	URL     string    `json:"url"`
+	Info    AudioInfo `json:"info,omitempty"`
+}
+
 var htmlRegex = regexp.MustCompile("<[^<]+?>")
 
 // GetHTMLMessage returns an HTMLMessage with the body set to a stripped version of the provided HTML, in addition

--- a/responses.go
+++ b/responses.go
@@ -159,6 +159,9 @@ type RespSync struct {
 				Limited   bool    `json:"limited"`
 				PrevBatch string  `json:"prev_batch"`
 			} `json:"timeline"`
+			Ephemeral struct {
+				Events []Event `json:"events"`
+			} `json:"ephemeral"`
 		} `json:"join"`
 		Invite map[string]struct {
 			State struct {

--- a/sync.go
+++ b/sync.go
@@ -64,6 +64,10 @@ func (s *DefaultSyncer) ProcessResponse(res *RespSync, since string) (err error)
 			event.RoomID = roomID
 			s.notifyListeners(&event)
 		}
+		for _, event := range roomData.Ephemeral.Events {
+			event.RoomID = roomID
+			s.notifyListeners(&event)
+		}
 	}
 	for roomID, roomData := range res.Rooms.Invite {
 		room := s.getOrCreateRoom(roomID)


### PR DESCRIPTION
Hi,
I added support for ephemeral events to sync.go.
My bot (mycete) needs to receive m.typing to warn users in time about the possibly unintented effects sending a message in a controlling room might have. 

I also added AudioMessage, LocationMessage and FileMessage in case someone needs it.