### PR TITLE
Run CI using golangci-lint, Go 1.13.10

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,21 @@
+run:
+  timeout: 5m
+  linters:
+    enable:
+      - vet
+      - vetshadow
+      - typecheck
+      - deadcode
+      - gocyclo
+      - golint
+      - varcheck
+      - structcheck
+      - maligned
+      - ineffassign
+      - misspell
+      - unparam
+      - goimports
+      - goconst
+      - unconvert
+      - errcheck
+      - interfacer

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: go
 go:
- - 1.10.x
+ - 1.13.10
 install:
- - go get github.com/golang/lint/golint
- - go get github.com/fzipp/gocyclo
- - go get github.com/client9/misspell/...
- - go get github.com/gordonklaus/ineffassign
+ - go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
+ - go build
 script: ./hooks/pre-commit

--- a/client.go
+++ b/client.go
@@ -55,10 +55,7 @@ func (e HTTPError) Error() string {
 
 // BuildURL builds a URL with the Client's homserver/prefix/access_token set already.
 func (cli *Client) BuildURL(urlPath ...string) string {
-	ps := []string{cli.Prefix}
-	for _, p := range urlPath {
-		ps = append(ps, p)
-	}
+	ps := append([]string{cli.Prefix}, urlPath...)
 	return cli.BuildBaseURL(ps...)
 }
 

--- a/client_examples_test.go
+++ b/client_examples_test.go
@@ -46,7 +46,7 @@ func Example_customInterfaces() {
 	cli.Client = http.DefaultClient
 
 	// Once you call a function, you can't safely change the interfaces.
-	cli.SendText("!foo:bar", "Down the rabbit hole")
+	_, _ = cli.SendText("!foo:bar", "Down the rabbit hole")
 }
 
 func ExampleClient_BuildURLWithQuery() {

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -2,9 +2,6 @@
 
 set -eu
 
-golint
-misspell --error .
-
 # gofmt doesn't exit with an error code if the files don't match the expected
 # format. So we have to run it and see if it outputs anything.
 if gofmt -l -s . 2>&1 | read
@@ -18,9 +15,5 @@ then
     exit 1
 fi
 
-ineffassign .
-
-go fmt
-go tool vet --all --shadow .
-gocyclo -over 12 .
-go test -timeout 5s -test.v
+golangci-lint run
+go test -timeout 5s . ./...

--- a/room.go
+++ b/room.go
@@ -31,8 +31,8 @@ func (room Room) UpdateState(event *Event) {
 
 // GetStateEvent returns the state event for the given type/state_key combo, or nil.
 func (room Room) GetStateEvent(eventType string, stateKey string) *Event {
-	stateEventMap, _ := room.State[eventType]
-	event, _ := stateEventMap[stateKey]
+	stateEventMap := room.State[eventType]
+	event := stateEventMap[stateKey]
 	return event
 }
 


### PR DESCRIPTION
This updates the CI for gomatrix to use Go 1.13.10 and to use golangci-lint instead of the older tools. This also fixes some small issues found by the linter.