### PR TITLE
Switch from access_token in URL to token in header

### DIFF
--- a/client_examples_test.go
+++ b/client_examples_test.go
@@ -55,7 +55,7 @@ func ExampleClient_BuildURLWithQuery() {
 		"filter_id": "5",
 	})
 	fmt.Println(out)
-	// Output: https://matrix.org/_matrix/client/r0/sync?access_token=abcdef123456&filter_id=5
+	// Output: https://matrix.org/_matrix/client/r0/sync?filter_id=5
 }
 
 func ExampleClient_BuildURL() {
@@ -63,7 +63,7 @@ func ExampleClient_BuildURL() {
 	cli, _ := NewClient("https://matrix.org", userID, "abcdef123456")
 	out := cli.BuildURL("user", userID, "filter")
 	fmt.Println(out)
-	// Output: https://matrix.org/_matrix/client/r0/user/@example:matrix.org/filter?access_token=abcdef123456
+	// Output: https://matrix.org/_matrix/client/r0/user/@example:matrix.org/filter
 }
 
 func ExampleClient_BuildBaseURL() {
@@ -71,7 +71,7 @@ func ExampleClient_BuildBaseURL() {
 	cli, _ := NewClient("https://matrix.org", userID, "abcdef123456")
 	out := cli.BuildBaseURL("_matrix", "client", "r0", "directory", "room", "#matrix:matrix.org")
 	fmt.Println(out)
-	// Output: https://matrix.org/_matrix/client/r0/directory/room/%23matrix:matrix.org?access_token=abcdef123456
+	// Output: https://matrix.org/_matrix/client/r0/directory/room/%23matrix:matrix.org
 }
 
 // Retrieve the content of a m.room.name state event.

--- a/client_test.go
+++ b/client_test.go
@@ -150,5 +150,8 @@ type MockRoundTripper struct {
 }
 
 func (t MockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("Authorization") == "" {
+		panic("no auth")
+	}
 	return t.RT(req)
 }


### PR DESCRIPTION
Avoid access_token in reverse proxy logs. And header seems preferred: https://github.com/matrix-org/matrix-doc/issues/1043

Old PR failed: #76 